### PR TITLE
package.json - move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "reactify": "^0.17.1"
   },
   "dependencies": {
-    "js-stylesheet": "0.0.1",
+    "js-stylesheet": "0.0.1"
+  },
+  "peerDependencies": {
     "react": "^0.12.1"
   }
 }


### PR DESCRIPTION
Fixes issue "Cannot read property 'firstChild' of undefined" that happens when 2 versions of react are loaded simultaneously.
See http://stackoverflow.com/a/27153167