### PR TITLE
Replace component.getDOMNode() with React.findDOMNode(component)

### DIFF
--- a/lib/components/Tab.js
+++ b/lib/components/Tab.js
@@ -39,11 +39,11 @@ module.exports = React.createClass({
 	},
 
 	componentDidMount() {
-    syncNodeAttributes(this.getDOMNode(), this.props);
+    syncNodeAttributes(React.findDOMNode(this), this.props);
 	},
 
 	componentDidUpdate() {
-    syncNodeAttributes(this.getDOMNode(), this.props);
+    syncNodeAttributes(React.findDOMNode(this), this.props);
 	},
 
 	render() {

--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -120,7 +120,7 @@ module.exports = React.createClass({
     // Look for non-disabled tab from index to the last tab on the right
     for (let i = index + 1; i < count; i++) {
       const tab = this.getTab(i);
-      if (!isTabDisabled(tab.getDOMNode())) {
+      if (!isTabDisabled(React.findDOMNode(tab))) {
         return i;
       }
     }
@@ -128,7 +128,7 @@ module.exports = React.createClass({
     // If no tab found, continue searching from first on left to index
     for (let i = 0; i < index; i++) {
       const tab = this.getTab(i);
-      if (!isTabDisabled(tab.getDOMNode())) {
+      if (!isTabDisabled(React.findDOMNode(tab))) {
         return i;
       }
     }
@@ -143,7 +143,7 @@ module.exports = React.createClass({
     // Look for non-disabled tab from index to first tab on the left
     while (i--) {
       const tab = this.getTab(i);
-      if (!isTabDisabled(tab.getDOMNode())) {
+      if (!isTabDisabled(React.findDOMNode(tab))) {
         return i;
       }
     }
@@ -152,7 +152,7 @@ module.exports = React.createClass({
     i = this.getTabsCount();
     while (i-- > index) {
       const tab = this.getTab(i);
-      if (!isTabDisabled(tab.getDOMNode())) {
+      if (!isTabDisabled(React.findDOMNode(tab))) {
         return i;
       }
     }


### PR DESCRIPTION
Since React 0.13 there is a new API for getting the DOM node from a component. In 0.14 they are also deprecating getDOMNode().

I replaced all occurrences of component.getDOMNode() with React.findDOMNode(component).
