### PR TITLE
Remove JSX comment from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ http://mzabriskie.github.io/react-tabs/example/
 ## Example
 
 ```js
-/** @jsx React.DOM */
 var React = require('react');
 var ReactTabs = require('react-tabs');
 var Tab = ReactTabs.Tab;


### PR DESCRIPTION
As the react dependency is 0.13, it is not needed anymore.

Sorry for spamming with PR :)