### PR TITLE
Avoid white-on-white Tab Labels

### DIFF
--- a/lib/helpers/styles.js
+++ b/lib/helpers/styles.js
@@ -19,6 +19,7 @@ module.exports = {
   '.react-tabs [role=tab][aria-selected=true]': {
     'background': '#fff',
     'border-color': '#aaa',
+    'color': 'black',
     'border-radius': '5px 5px 0 0',
     '-moz-border-radius': '5px 5px 0 0',
     '-webkit-border-radius': '5px 5px 0 0'


### PR DESCRIPTION
I'm using `react-tabs` alongside a CSS framework that sets the global text color to white. This PR fixes that by explicitly setting the color to black.