### PR TITLE
[fixed] Server Side Rendering won't work with default styles #45

### DIFF
--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -57,7 +57,7 @@ module.exports = React.createClass({
     };
   },
 
-  componentWillMount() {
+  componentDidMount() {
     if (useDefaultStyles) {
       jss(require('../helpers/styles.js'));
     }


### PR DESCRIPTION
Moving injection of styles from `componentWillMount` to `componentDidMount`. Solves https://github.com/rackt/react-tabs/issues/45