### PR TITLE
Fix defaultProps for forceRenderTabPanel

### DIFF
--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -43,7 +43,7 @@ module.exports = React.createClass({
     return {
       selectedIndex: -1,
       focus: false,
-      focusRenderTabPanel: false
+      forceRenderTabPanel: false
     };
   },
 


### PR DESCRIPTION
Was changed in f360ce672b291d19fa1806e535d7bf2092b30892
and it is the only place where focusRenderTabPanel appears, so i think this was done by mistake.