### PR TITLE
Soften requirements so updates can be installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-addons-test-utils": "^0.14.0"
   },
   "dependencies": {
-    "classnames": "2.2.0",
-    "js-stylesheet": "0.0.1"
+    "classnames": "^2.2",
+    "js-stylesheet": "^0.0.1"
   }
 }


### PR DESCRIPTION
for example it is not possible to install classnames 2.2.1. And as you are really slow in responding to even the smallest changes, i made the dependency ^2.2 so even 2.3 could be used.