### PR TITLE
Fix onSelect method name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var App = React.createClass({
       */}
 
       <Tabs
-        onSelect={this.handleSelected}
+        onSelect={this.handleSelect}
         selectedIndex={2}
       >
 


### PR DESCRIPTION
`onSelect`-handle was called `{this.handleSelected}` while the method was `handleSelect`. This PR fixes that minor issue.